### PR TITLE
Fixed incorrect creation URLs from non absolute one

### DIFF
--- a/goscraper.go
+++ b/goscraper.go
@@ -382,10 +382,8 @@ func (scraper *Scraper) parseDocument(doc *Document) error {
 					return err
 				}
 				if !ogImgUrl.IsAbs() {
-					ogImgUrl, err = url.Parse(fmt.Sprintf("%s://%s%s", scraper.Url.Scheme, scraper.Url.Host, ogImgUrl.Path))
-					if err != nil {
-						return err
-					}
+					ogImgUrl.Host = scraper.Url.Host
+					ogImgUrl.Scheme = scraper.Url.Scheme
 				}
 
 				doc.Preview.Images = []string{ogImgUrl.String()}


### PR DESCRIPTION
Due the reason that we "re-create" new link - only by scheme, host and path - is present risk to loose some other data from original link. 
Previously `/some/path.png?param=value`, was transformed into `http://mydomain.com/some/path.png`
Now this issue should be fixed, and output should be `http://mydomain.com/some/path.png?param=value`